### PR TITLE
embulk-output-sftp で並列実行した際の null エラーのハンドリング

### DIFF
--- a/embulk-formatter-jsonl.gemspec
+++ b/embulk-formatter-jsonl.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "embulk-formatter-jsonl"
-  spec.version       = "0.1.4.trocco.0.0.Beta1"
+  spec.version       = "0.1.4.trocco.0.0.1"
   spec.authors       = ["TAKEI Yuya"]
   spec.summary       = "Jsonl formatter plugin for Embulk"
   spec.description   = "Formats Embulk Formatter Jsonl files for other file output plugins."

--- a/embulk-formatter-jsonl.gemspec
+++ b/embulk-formatter-jsonl.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "embulk-formatter-jsonl"
-  spec.version       = "0.1.4"
+  spec.version       = "0.1.4.trocco.0.0.Beta1"
   spec.authors       = ["TAKEI Yuya"]
   spec.summary       = "Jsonl formatter plugin for Embulk"
   spec.description   = "Formats Embulk Formatter Jsonl files for other file output plugins."

--- a/lib/embulk/formatter/jsonl.rb
+++ b/lib/embulk/formatter/jsonl.rb
@@ -71,12 +71,15 @@ module Embulk
           @schema.each do |col|
             datum[col.name] = @json_columns.include?(col.name) ? JrJackson::Json.load(record[col.index]) : record[col.index]
           end
-          @current_file.write "#{JrJackson::Json.dump(datum, @opts )}#{@newline}".encode(@encoding)
+
+          data_str = "#{JrJackson::Json.dump(datum, @opts)}#{@newline}".encode(@encoding)
+          @current_file.write data_str
+          @current_file_size += data_str.bytesize
         end
       end
 
       def finish
-        file_output.finish
+        file_output.finish unless @current_file.nil?
       end
     end
 


### PR DESCRIPTION
# この PR はなぜ必要なのか (Why)
- embulk-output-sftp で jsonl を指定して、並列でタスクを実行(並列転送)した際に、一部の output のタスクが embulk-output-sftp 側で null エラーが発生して処理が落ちていた
```
2023-09-21 03:14:35.198 +0000 [INFO] (0001:transaction): Using local thread executor with max_threads=32 / output tasks 16 = input tasks 1 * 16
...
2023-09-21 03:14:36.019 +0000 [INFO] (0034:task-0000): Upload completed.
2023-09-21 02:04:38.878 +0000 [WARN] (0036:task-0000): SFTP upload file 'null' failed. Retrying 1/5 after 0 seconds. Message: null
2023-09-21 02:04:39.658 +0000 [WARN] (0036:task-0000): SFTP upload file 'null' failed. Retrying 2/5 after 1 seconds. Message: null
2023-09-21 02:04:40.940 +0000 [WARN] (0036:task-0000): SFTP upload file 'null' failed. Retrying 3/5 after 2 seconds. Message: null
java.lang.NullPointerException: null
	at org.embulk.output.sftp.SftpUtils.newSftpFile(SftpUtils.java:293) [embulk-output-sftp-0.2.1.jar:na]
	at org.embulk.output.sftp.SftpUtils$1.call(SftpUtils.java:160) ~[na:na]
	at org.embulk.output.sftp.SftpUtils$1.call(SftpUtils.java:156) ~[na:na]
	at org.embulk.spi.util.RetryExecutor.run(RetryExecutor.java:81) [embulk:0.9.26]
	at org.embulk.spi.util.RetryExecutor.runInterruptible(RetryExecutor.java:62) [embulk:0.9.26]
	at org.embulk.output.sftp.SftpUtils.withRetry(SftpUtils.java:321) [embulk-output-sftp-0.2.1.jar:na]
```
- 当初はエラー発生してる embulk-output-sftp 方でエラー回避を行っていたが、formatter 側で file の存在確認を行った上で finish を実行すればエラーの回避が出来そうだったのでその方向で対応を行った
  - https://github.com/embulk/embulk-output-sftp/pull/68

# この PR は何をやっているのか (What)
- current_file の存在確認を行って、current_file が存在していたら finish が走るようにした
- current_file_size のチェック機能が正常に動作していなそうだったので修正を行った

# Issue / Reference
- ref: https://github.com/primenumber-dev/n-transfer-ui/issues/18150

# その他
- https://github.com/primenumber-dev/n-transfer-ui/issues/18150#issuecomment-1729141441