### PR TITLE
全てのレコードが転送されるように修正

### DIFF
--- a/embulk-formatter-jsonl.gemspec
+++ b/embulk-formatter-jsonl.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "embulk-formatter-jsonl"
-  spec.version       = "0.1.4.trocco.0.0.1"
+  spec.version       = "0.1.4.trocco.0.0.2"
   spec.authors       = ["TAKEI Yuya"]
   spec.summary       = "Jsonl formatter plugin for Embulk"
   spec.description   = "Formats Embulk Formatter Jsonl files for other file output plugins."

--- a/lib/embulk/formatter/jsonl.rb
+++ b/lib/embulk/formatter/jsonl.rb
@@ -71,10 +71,7 @@ module Embulk
           @schema.each do |col|
             datum[col.name] = @json_columns.include?(col.name) ? JrJackson::Json.load(record[col.index]) : record[col.index]
           end
-
-          data_str = "#{JrJackson::Json.dump(datum, @opts)}#{@newline}".encode(@encoding)
-          @current_file.write data_str
-          @current_file_size += data_str.bytesize
+          @current_file.write "#{JrJackson::Json.dump(datum, @opts)}#{@newline}".encode(@encoding)
         end
       end
 


### PR DESCRIPTION
### why
- https://github.com/primenumber-dev/n-transfer-ui/issues/19524#issuecomment-1738299294 で一部レコードが正常に転送されない現象を確認
- local 環境で同条件で実行しても再現しないが、max_threads スレッド数や output のタスク数が差分として生じていそう
- 挙動としては add メソッドの呼び出し回数に寄与していそうで、元の実装だと add メソッド内で byte 数によって新規ファイルを生成する挙動を修正していたために、ファイルの書き込みを行ったファイルの転送が出来ていなかった

### what
- 既存の実装に revert して動作確認を行う

### その他
- ref: https://github.com/primenumber-dev/n-transfer-ui/issues/18150 